### PR TITLE
Separate TS types and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,24 @@ RBAC expects an object with roles as property names.
 
 ###### IMPORTANT! **"when"** property should be either a Callback function that receives params and done or a Promise that should resolve in [Truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) or [Falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) values. Example: 
 
-``` javascript 
+```ts
+import type { Roles } from '@rbac/rbac';
 
-const roles = {
+interface Params {
+  registered: boolean;
+}
+
+const roles: Roles<Params> = {
   supervisor: {
     can: [{ name: 'products:find', when: (params, done) => {
       // done receives error as first argument and Truthy or Falsy value as second argument
-      done(error, false);
+      done(null, params.registered);
     }}]
   },
   admin: {
-    can: [{name: 'products:*', when: new Promise((resolve) => {
+    can: [{ name: 'products:*', when: new Promise((resolve) => {
       resolve(true);
-    })}]
+    }) }]
   }
 };
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-`./configuredRBAC.js`:
+`./configuredRBAC.ts`:
 
-```javascript
+```ts
 import rbac from '@rbac/rbac';
 
 const rbacConfig = {
@@ -10,21 +10,23 @@ const rbacConfig = {
 export const configuredRBAC = rbac(rbacConfig);
 ```
 
-`./RBAC.js`:
+`./RBAC.ts`:
 
-```javascript
+```ts
 import configuredRBAC from './configuredRBAC';
 
-const roles = {
+import type { Roles } from '@rbac/rbac';
+
+const roles: Roles = {
   user: {
     can: ['products:find']
   },
   supervisor: {
-    can: [{name: 'products:find', when: PromiseThatReturnsTruthyOrFalsyValue }],
+    can: [{ name: 'products:find', when: PromiseThatReturnsTruthyOrFalsyValue }],
     inherits: ['user']
   },
   admin: {
-    can: [{name: 'products:delete', when: FunctionThatReturnsTruthyOrFalsyValue }],
+    can: [{ name: 'products:delete', when: FunctionThatReturnsTruthyOrFalsyValue }],
     inherits: ['supervisor']
   },
   superadmin: {
@@ -35,9 +37,9 @@ const roles = {
 export const RBAC = configuredRBAC(roles);
 ```
 
-`./example.js`:
+`./example.ts`:
 
-```javascript
+```ts
 import RBAC from './RBAC';
 
 const myUser = {
@@ -54,7 +56,7 @@ RBAC.can(myUser.role, 'products:find')
  .then(result => {
    doSomething(result);
  })
- .catch(error => {
-   somethingWentWrong();
- });
+  .catch(error => {
+    somethingWentWrong();
+  });
 ```

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,5 @@
+import type { When, WhenCallback, GlobFromRole } from './types';
+
 const is = (value: unknown, expected: string): boolean =>
   !!value && Object.prototype.toString.call(value) === expected;
 
@@ -93,12 +95,6 @@ export const globToRegex = (glob: string | string[]): RegExp =>
 export const checkRegex = (regex: RegExp, can: Record<string, unknown>): boolean =>
   Object.keys(can).some(operation => regex.test(operation));
 
-export interface GlobFromRole<P = unknown> {
-  role: string;
-  regex: RegExp;
-  when: When<P> | true;
-}
-
 export const globsFromFoundedRole = <P = unknown>(can: Record<string, When<P> | true>): GlobFromRole<P>[] =>
   Object.keys(can)
     .map(role =>
@@ -110,9 +106,4 @@ export const globsFromFoundedRole = <P = unknown>(can: Record<string, When<P> | 
     )
     .filter(Boolean) as GlobFromRole<P>[];
 
-export type WhenCallback<P = unknown> = (
-  params: P,
-  done: (err: unknown, result?: boolean) => void
-) => void;
-
-export type When<P = unknown> = boolean | Promise<boolean> | WhenCallback<P>;
+export type { When, WhenCallback, GlobFromRole } from './types';

--- a/src/rbac.ts
+++ b/src/rbac.ts
@@ -1,25 +1,15 @@
 import * as helpers from './helpers';
-import type { When, GlobFromRole } from './helpers';
+import type {
+  When,
+  GlobFromRole,
+  RBACConfig,
+  Role,
+  Roles,
+  MappedRole,
+  MappedRoles
+} from './types';
 
-export interface RBACConfig {
-  logger?: (role: string, operation: string | RegExp, result: boolean) => void;
-  enableLogger?: boolean;
-}
-
-export interface Role<P = unknown> {
-  can: Array<string | { name: string; when: When<P> }>;
-  inherits?: string[];
-}
-
-export type Roles<P = unknown> = Record<string, Role<P>>;
-
-interface MappedRole<P = unknown> {
-  can: Record<string, When<P> | true>;
-  inherits?: string[];
-  globs: GlobFromRole<P>[];
-}
-
-type MappedRoles<P = unknown> = Record<string, MappedRole<P>>;
+export type { RBACConfig, Role, Roles } from './types';
 
 const can =
   <P>(config: RBACConfig = { logger: helpers.defaultLogger, enableLogger: true }) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,32 @@
+export interface RBACConfig {
+  logger?: (role: string, operation: string | RegExp, result: boolean) => void;
+  enableLogger?: boolean;
+}
+
+export type WhenCallback<P = unknown> = (
+  params: P,
+  done: (err: unknown, result?: boolean) => void
+) => void;
+
+export type When<P = unknown> = boolean | Promise<boolean> | WhenCallback<P>;
+
+export interface GlobFromRole<P = unknown> {
+  role: string;
+  regex: RegExp;
+  when: When<P> | true;
+}
+
+export interface Role<P = unknown> {
+  can: Array<string | { name: string; when: When<P> }>;
+  inherits?: string[];
+}
+
+export type Roles<P = unknown> = Record<string, Role<P>>;
+
+export interface MappedRole<P = unknown> {
+  can: Record<string, When<P> | true>;
+  inherits?: string[];
+  globs: GlobFromRole<P>[];
+}
+
+export type MappedRoles<P = unknown> = Record<string, MappedRole<P>>;


### PR DESCRIPTION
## Summary
- move interfaces and types to new `src/types.ts`
- import types from new file and re-export as needed
- document typed usage in the main README
- update example docs to use TypeScript syntax

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68452d76e27c8325a561e696c368e7f4