### PR TITLE
Convert examples to TypeScript

### DIFF
--- a/examples/constants.js
+++ b/examples/constants.js
@@ -1,8 +1,0 @@
-export const USER = 'user';
-export const SUPERVISOR = 'supervisor';
-export const SUPERVISORWITHOUTPERMISSION = 'supervisor_without_permissions';
-export const ADMIN = 'admin';
-export const SUPERADMIN = 'superadmin';
-export const PRODUCTS_FIND = 'products:find';
-export const PRODUCTS_EDIT = 'products:edit';
-export const PRODUCTS_DELETE = 'products:delete';

--- a/examples/constants.ts
+++ b/examples/constants.ts
@@ -1,0 +1,20 @@
+export const USER = 'user' as const;
+export const SUPERVISOR = 'supervisor' as const;
+export const SUPERVISORWITHOUTPERMISSION = 'supervisor_without_permissions' as const;
+export const ADMIN = 'admin' as const;
+export const SUPERADMIN = 'superadmin' as const;
+export const PRODUCTS_FIND = 'products:find' as const;
+export const PRODUCTS_EDIT = 'products:edit' as const;
+export const PRODUCTS_DELETE = 'products:delete' as const;
+
+export type RoleName =
+  | typeof USER
+  | typeof SUPERVISOR
+  | typeof SUPERVISORWITHOUTPERMISSION
+  | typeof ADMIN
+  | typeof SUPERADMIN;
+
+export type Operation =
+  | typeof PRODUCTS_FIND
+  | typeof PRODUCTS_EDIT
+  | typeof PRODUCTS_DELETE;

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -8,18 +8,19 @@ import {
   PRODUCTS_FIND
 } from './constants';
 
-import rbac from '../src/rbac';
+import rbac from '../src';
+import type { Roles } from '../src/types';
 
-const defaultRoles = {
+const defaultRoles: Roles = {
   [USER]: {
     can: [PRODUCTS_FIND]
   },
   [SUPERVISOR]: {
-    can: [{name: PRODUCTS_EDIT }],
+    can: [{ name: PRODUCTS_EDIT }],
     inherits: [USER]
   },
   [ADMIN]: {
-    can: [{name: PRODUCTS_DELETE }],
+    can: [{ name: PRODUCTS_DELETE }],
     inherits: [SUPERVISOR]
   },
   [SUPERADMIN]: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc && vite build && npm run test",
     "dev": "tsc -w",
-    "examples": "node -r @babel/register ./examples/index.js",
+    "examples": "node -r ts-node/register ./examples/index.ts",
     "test": "NODE_ENV=test mocha --require @babel/register --colors ./test/*.spec.js",
     "test:watch": "NODE_ENV=test mocha --require @babel/register --colors -w ./test/*.spec.js",
     "test:npm": "cd test/npm-test && npm install && npm test"


### PR DESCRIPTION
## Summary
- convert example files from JS to TS and add string literal types
- point examples script to ts-node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68452f42f1b8832587ecf8aa04c5f926