### PR TITLE
Add runtime role update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,32 @@ const roles: Roles<Params> = {
 | First  	| **String**  	                                 | ```'admin'```            	| Array of strings, list of operations that user can do          	|
 | Second 	| **String**, **Glob (Wildcard)**, **Regex**     | ```'products:find'```    	| Operation to validate                                          	|
 | Third  	| **Any**     	                                 | ```{registered: true}``` 	| **Optional** Params that will flow to "when" callback Function 	|
+### Update roles at runtime
 
+RBAC exposes two helpers to modify the role definition at runtime. `addRole` adds a new role and `updateRoles` merges new definitions with the existing ones.
+
+```ts
+import RBAC from '@rbac/rbac'
+
+const base = RBAC({ enableLogger: false })({
+  user: { can: ['products:find'] }
+})
+
+base.addRole('editor', { can: ['products:update'], inherits: ['user'] })
+await base.can('editor', 'products:update') // true
+
+base.updateRoles({
+  user: { can: ['products:find', 'products:create'] }
+})
+await base.can('user', 'products:create') // true
+```
 Want more? Check out the [examples](examples/) folder.
 
 ## Roadmap
 
 - [X] Wildcard support
 - [X] Regex support
-- [ ] Update roles in runtime
+- [X] Update roles in runtime
 
 ## v2.0.0
 

--- a/lib/helpers.d.ts
+++ b/lib/helpers.d.ts
@@ -1,3 +1,4 @@
+import type { When, GlobFromRole } from './types';
 export declare const isGlob: (value: unknown) => value is string;
 export declare const isPromise: <T = unknown>(value: unknown) => value is Promise<T>;
 export declare const isFunction: (value: unknown) => value is Function;
@@ -13,11 +14,5 @@ export declare const validators: {
 export declare const regexFromOperation: (value: string | RegExp) => RegExp | null;
 export declare const globToRegex: (glob: string | string[]) => RegExp;
 export declare const checkRegex: (regex: RegExp, can: Record<string, unknown>) => boolean;
-export interface GlobFromRole<P = unknown> {
-    role: string;
-    regex: RegExp;
-    when: When<P> | true;
-}
 export declare const globsFromFoundedRole: <P = unknown>(can: Record<string, When<P> | true>) => GlobFromRole<P>[];
-export type WhenCallback<P = unknown> = (params: P, done: (err: unknown, result?: boolean) => void) => void;
-export type When<P = unknown> = boolean | Promise<boolean> | WhenCallback<P>;
+export type { When, WhenCallback, GlobFromRole } from './types';

--- a/lib/rbac.d.ts
+++ b/lib/rbac.d.ts
@@ -1,17 +1,8 @@
-import type { When } from './helpers';
-export interface RBACConfig {
-    logger?: (role: string, operation: string | RegExp, result: boolean) => void;
-    enableLogger?: boolean;
-}
-export interface Role<P = unknown> {
-    can: Array<string | {
-        name: string;
-        when: When<P>;
-    }>;
-    inherits?: string[];
-}
-export type Roles<P = unknown> = Record<string, Role<P>>;
+import type { RBACConfig, Role, Roles } from './types';
+export type { RBACConfig, Role, Roles } from './types';
 declare const RBAC: <P>(config?: RBACConfig) => (roles: Roles<P>) => {
-    can: (role: string, operation: string | RegExp, params?: P | undefined) => Promise<boolean>;
+    can: (role: string, operation: string | RegExp, params?: P) => Promise<boolean>;
+    updateRoles: (newRoles: Roles<P>) => void;
+    addRole: (roleName: string, roleDef: Role<P>) => void;
 };
 export default RBAC;

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -119,7 +119,23 @@ const mapRoles = (roles) => {
         };
     }, {});
 };
-const RBAC = (config = {}) => (roles) => ({
-    can: can(config)(mapRoles(roles))
-});
+const RBAC = (config = {}) => (roles) => {
+    let allRoles = { ...roles };
+    let mappedRoles = mapRoles(allRoles);
+    const checker = can(config);
+    const canFn = (role, operation, params) => checker(mappedRoles)(role, operation, params);
+    const updateRoles = (newRoles) => {
+        allRoles = { ...allRoles, ...newRoles };
+        mappedRoles = mapRoles(allRoles);
+    };
+    const addRole = (roleName, roleDef) => {
+        allRoles = { ...allRoles, [roleName]: roleDef };
+        mappedRoles = mapRoles(allRoles);
+    };
+    return {
+        can: canFn,
+        updateRoles,
+        addRole
+    };
+};
 exports.default = RBAC;

--- a/src/rbac.ts
+++ b/src/rbac.ts
@@ -129,8 +129,32 @@ const mapRoles = <P>(roles: Roles<P>): MappedRoles<P> => {
 
 const RBAC =
   <P>(config: RBACConfig = {}) =>
-  (roles: Roles<P>) => ({
-    can: can<P>(config)(mapRoles(roles))
-  });
+  (roles: Roles<P>) => {
+    let allRoles = { ...roles };
+    let mappedRoles = mapRoles(allRoles);
+    const checker = can<P>(config);
+
+    const canFn = (
+      role: string,
+      operation: string | RegExp,
+      params?: P
+    ) => checker(mappedRoles)(role, operation, params);
+
+    const updateRoles = (newRoles: Roles<P>): void => {
+      allRoles = { ...allRoles, ...newRoles };
+      mappedRoles = mapRoles(allRoles);
+    };
+
+    const addRole = (roleName: string, roleDef: Role<P>): void => {
+      allRoles = { ...allRoles, [roleName]: roleDef };
+      mappedRoles = mapRoles(allRoles);
+    };
+
+    return {
+      can: canFn,
+      updateRoles,
+      addRole
+    };
+  };
 
 export default RBAC;

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,3 +30,9 @@ export interface MappedRole<P = unknown> {
 }
 
 export type MappedRoles<P = unknown> = Record<string, MappedRole<P>>;
+
+export interface RBACInstance<P = unknown> {
+  can: (role: string, operation: string | RegExp, params?: P) => Promise<boolean>;
+  updateRoles: (roles: Roles<P>) => void;
+  addRole: (roleName: string, role: Role<P>) => void;
+}

--- a/test/rbac.spec.js
+++ b/test/rbac.spec.js
@@ -251,4 +251,22 @@ describe('RBAC', () => {
       expect(result).to.be.false;
     });
   });
+
+  describe('runtime role updates', () => {
+    it('should allow permissions for a role added at runtime', async () => {
+      RBAC.addRole('editor', { can: ['products:update'], inherits: ['user'] });
+      const resEdit = await RBAC.can('editor', 'products:update');
+      const resFind = await RBAC.can('editor', 'products:find');
+      expect(resEdit).to.be.true;
+      expect(resFind).to.be.true;
+    });
+
+    it('should respect updated roles when using can', async () => {
+      RBAC.updateRoles({
+        user: { can: ['products:find', 'products:create'] }
+      });
+      const resCreate = await RBAC.can('user', 'products:create');
+      expect(resCreate).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- allow runtime updates to RBAC roles
- add `updateRoles` and `addRole` methods
- cover runtime updates in tests
- document runtime update behaviour in README

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845326b0df483258748831ac829c787