### PR TITLE
Add runtime role update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Want more? Check out the [examples](examples/) folder.
 
 ## v2.0.0
 
+- Rewritten in TypeScript
 - Internal refactor focused on readability and performance
+- Added support to update roles at runtime
 
 ## Contributing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,3 +60,30 @@ RBAC.can(myUser.role, 'products:find')
     somethingWentWrong();
   });
 ```
+
+`./updateRoles.ts`:
+
+```ts
+import rbac from '../src';
+import type { Roles } from '../src/types';
+import {
+  USER,
+  PRODUCTS_FIND,
+  PRODUCTS_UPDATE,
+  PRODUCTS_CREATE
+} from './constants';
+
+const baseRoles: Roles = {
+  [USER]: { can: [PRODUCTS_FIND] }
+};
+
+const RBAC = rbac()(baseRoles);
+
+RBAC.addRole('editor', { can: [PRODUCTS_UPDATE], inherits: [USER] });
+await RBAC.can('editor', PRODUCTS_UPDATE); // true
+
+RBAC.updateRoles({
+  [USER]: { can: [PRODUCTS_FIND, PRODUCTS_CREATE] }
+});
+await RBAC.can(USER, PRODUCTS_CREATE); // true
+```

--- a/examples/constants.ts
+++ b/examples/constants.ts
@@ -6,6 +6,8 @@ export const SUPERADMIN = 'superadmin' as const;
 export const PRODUCTS_FIND = 'products:find' as const;
 export const PRODUCTS_EDIT = 'products:edit' as const;
 export const PRODUCTS_DELETE = 'products:delete' as const;
+export const PRODUCTS_UPDATE = 'products:update' as const;
+export const PRODUCTS_CREATE = 'products:create' as const;
 
 export type RoleName =
   | typeof USER
@@ -17,4 +19,6 @@ export type RoleName =
 export type Operation =
   | typeof PRODUCTS_FIND
   | typeof PRODUCTS_EDIT
-  | typeof PRODUCTS_DELETE;
+  | typeof PRODUCTS_DELETE
+  | typeof PRODUCTS_UPDATE
+  | typeof PRODUCTS_CREATE;

--- a/examples/updateRoles.ts
+++ b/examples/updateRoles.ts
@@ -1,0 +1,26 @@
+import rbac from '../src';
+import type { Roles } from '../src/types';
+import {
+  USER,
+  PRODUCTS_FIND,
+  PRODUCTS_UPDATE,
+  PRODUCTS_CREATE
+} from './constants';
+
+const baseRoles: Roles = {
+  [USER]: { can: [PRODUCTS_FIND] }
+};
+
+const RBAC = rbac()(baseRoles);
+
+async function run(): Promise<void> {
+  RBAC.addRole('editor', { can: [PRODUCTS_UPDATE], inherits: [USER] });
+  await RBAC.can('editor', PRODUCTS_UPDATE); // true
+
+  RBAC.updateRoles({
+    [USER]: { can: [PRODUCTS_FIND, PRODUCTS_CREATE] }
+  });
+  await RBAC.can(USER, PRODUCTS_CREATE); // true
+}
+
+run().catch(console.error);


### PR DESCRIPTION
## Summary
- add `PRODUCTS_UPDATE` and `PRODUCTS_CREATE` constants
- document runtime role updates in examples
- add `updateRoles.ts` example for updating roles at runtime
- mention TypeScript rewrite and runtime role updates in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845352d0b6883258f1ae1f024174b60