### PR TITLE
Fix CircleCI workflow trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,13 +131,3 @@ workflows:
                 - /hotfix\/.*/
                 - /release\/.*/
 
-    when:
-      pull-requests:
-        only: true
-      branches:
-        only:
-          - main
-          - develop
-          - /feature\/.*/
-          - /hotfix\/.*/
-          - /release\/.*/


### PR DESCRIPTION
## Summary
- remove invalid `when` section from CircleCI workflow

## Testing
- `yarn build`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6845b5aaffec8325ac09e01cb0f3c36d