### PR TITLE
Add migration guide and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.0] - 2025-06-08
+### Added
+- Multi-tenant support via `createTenantRBAC`.
+- Option to configure table and column names for database adapters.
+
+### Changed
+- Improved CircleCI configuration.
+
+## [2.0.0] - 2025-06-08
+### Added
+- Completely rewritten in TypeScript.
+- Ability to update roles at runtime (`updateRoles`).
+- Adapters for MongoDB, MySQL and PostgreSQL.
+- Official middlewares for Express, NestJS and Fastify.

--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ respectively with a similar API.
 - Database adapters
 - Middlewares for Express, NestJS and Fastify
 
+## More Information
+
+- [Migration guide from v1 to v2](docs/migrating-v1-to-v2.md)
+- [Changelog](CHANGELOG.md)
+
 ## Contributing
 
 #### Contributions are welcome!

--- a/docs/migrating-v1-to-v2.md
+++ b/docs/migrating-v1-to-v2.md
@@ -1,0 +1,21 @@
+# Migrating from v1 to v2
+
+This guide summarizes the main changes introduced in version 2 of **RBAC** and how to update your applications.
+
+## Main changes
+
+- **Complete rewrite in TypeScript.** The API remains compatible but the source files are now in TypeScript for better type support and public declarations.
+- **Dynamic role updates.** The `updateRoles` function allows modifying permissions at runtime.
+- **Database adapters.** New adapters for MongoDB, MySQL and PostgreSQL make it possible to automatically load and persist roles.
+- **Official middlewares.** Middlewares for Express, NestJS and Fastify make protecting routes easier.
+- **Multi-tenant support.** Use `createTenantRBAC` to instantiate isolated RBAC instances per tenant.
+
+## Steps to update
+
+1. Update your `package.json` dependency to `@rbac/rbac@^2.0.0` or the latest version.
+2. If you use plain JavaScript, no changes are required. For TypeScript, import the types exposed by `@rbac/rbac`.
+3. If you previously loaded roles manually, consider using a database adapter to centralize persistence.
+4. Review your calls to `RBAC.can` and other utilities; the API is the same but `when` can now be an async function or promise.
+5. For a gradual migration, keep your existing `.js` files and adopt `.ts` as needed.
+
+For more details check the [CHANGELOG](../CHANGELOG.md).


### PR DESCRIPTION
## Summary
- document how to migrate from v1 to v2
- add versioned changelog following Keep a Changelog
- reference the docs from the README
- translate migration docs to English

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845bcc0b8b08325a816e4d7f41207b7