### PR TITLE
Optimize inherited role checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ### Changed
 - Simplified helper utilities using TypeScript features
+- Rebuild role hierarchy when roles change at runtime to improve permission checks
+- Flatten inherited permissions for faster lookups
 
 ### Benchmark
-- direct permission: ~74k ops/s
-- inherited permission: ~37k ops/s
-- glob permission: ~72k ops/s
+- direct permission: ~70k ops/s
+- inherited permission: ~72k ops/s
+- glob permission: ~64k ops/s
 
 ## [2.1.0] - 2025-06-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Run `npm run bench` to execute performance tests.
 
 ```
 $ npm run bench
-Benchmark ops/sec: 50045 (direct), 24450 (inherited), 48475 (glob)
+Benchmark ops/sec: 70226 (direct), 72048 (inherited), 63802 (glob)
 ```
 
 ## More Information


### PR DESCRIPTION
## Summary
- precompute merged permissions for each role
- rebuild merged map when roles change
- cover edge cases like cycles and missing parents
- refresh benchmark data and readme

## Testing
- `npm run build`
- `npm test`
- `npm run bench`


------
https://chatgpt.com/codex/tasks/task_e_6845cdc8408483259984ba0919ee412c