### PR TITLE
chore(ci): update node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cimg/node:20.16.0
+      - image: cimg/node:20.19.0
     working_directory: ~/rbac
 
     steps:
@@ -69,7 +69,7 @@ jobs:
 
   test-npm:
     docker:
-      - image: cimg/node:20.16.0
+      - image: cimg/node:20.19.0
     working_directory: ~/rbac
 
     steps:


### PR DESCRIPTION
## Summary
- use Node 20.19.0 in CircleCI builds to satisfy newer dependency requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e34290b083259ffd006188bb5010